### PR TITLE
added isolate profile for system python

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ space-separated list of isolation profiles, any of
 * `gcc`: Deny access to `/usr/bin/gcc` and `/usr/bin/g++`, for
   environments where code should be using a separate compiler instead of
   an OS-packaged one.
+* `python`: Deny access to system `python` and `python3` in `/usr/bin`, 
+  For projects where code should be using a separate interpreter instead of an
+  OS-packaged one.
 
 Call `ts_isolate` at the beginning of your build or test runner, before
 it runs any user-provided code. In our monorepo, the very first step in

--- a/ts_isolate.c
+++ b/ts_isolate.c
@@ -392,6 +392,23 @@ ts_isolate_gcc(void)
 }
 
 static int
+ts_isolate_python(void)
+{
+    const char *script = "#!/bin/sh\necho error: \"$0\" from OS not allowed >&2\nexit 1\n";
+    const char *programs[] = {"/usr/bin/python", "/usr/bin/python3", NULL};
+    for (int i = 0; programs[i]; i++) {
+        if (overwrite_file(programs[i], "%s", script) != 0) {
+            return -1;
+        }
+        if (chmod(programs[i], 0755) != 0) {
+            warn("ts_isolate: chmod 755 %s", programs[i]);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int
 ts_isolate_ambient_admin(void)
 {
     /* This is only intended for tests that need to run fusermount,
@@ -466,6 +483,11 @@ ts_isolate(const char *profiles)
             .name = "gcc",
             .perform = ts_isolate_gcc,
             .namespaces = CLONE_NEWNS,
+        },
+        {
+            .name = "python",
+            .perform = ts_isolate_python,
+            .namespaces = CLONE_NEWNS
         },
         {
             .name = "ambient_admin",


### PR DESCRIPTION
Adding ts_isolate profile for default system python to address https://github.com/twosigma/ts_isolate/issues/2

This obviously will only find the "primary" python minor version for each major version on a particular system, and not any other installed versions, but I _think_ that's what we want here anyways?

```
➜  ts_isolate-kbiggers git:(python-isolate) ./ts_isolate "python" python -c "print('hi :)')" 
error: /usr/bin/python from OS not allowed
➜  ts_isolate-kbiggers git:(python-isolate) ./ts_isolate "python" python3 -c "print('hi :)')"
error: /usr/bin/python3 from OS not allowed
➜  ts_isolate-kbiggers git:(python-isolate) ./ts_isolate "python" python3.8 -c "print('hi :)')"
error: /usr/bin/python3.8 from OS not allowed
➜  ts_isolate-kbiggers git:(python-isolate) which python3.9                                    
/usr/local/bin/python3.9
➜  ts_isolate-kbiggers git:(python-isolate) ./ts_isolate "python" python3.9 -c "print('hi :)')"
hi :)
```